### PR TITLE
Tightened thread-safety

### DIFF
--- a/src/main/java/com/tananaev/adblib/AdbConnection.java
+++ b/src/main/java/com/tananaev/adblib/AdbConnection.java
@@ -7,7 +7,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.ConnectException;
 import java.net.Socket;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class represents an ADB connection.
@@ -32,39 +32,39 @@ public class AdbConnection implements Closeable {
      * The input stream that this class uses to read from
      * the socket.
      */
-    private InputStream inputStream;
+    private volatile InputStream inputStream;
 
     /**
      * The output stream that this class uses to read from
      * the socket.
      */
-    OutputStream outputStream;
+    volatile OutputStream outputStream;
 
     /**
      * The backend thread that handles responding to ADB packets.
      */
-    private Thread connectionThread;
+    private volatile Thread connectionThread;
 
     /**
      * Specifies whether a connect has been attempted
      */
-    private boolean connectAttempted;
+    private volatile boolean connectAttempted;
 
     /**
      * Specifies whether a CNXN packet has been received from the peer.
      */
-    private boolean connected;
+    private volatile boolean connected;
 
     /**
      * Specifies the maximum amount data that can be sent to the remote peer.
      * This is only valid after connect() returns successfully.
      */
-    private int maxData;
+    private volatile int maxData;
 
     /**
      * An initialized ADB crypto object that contains a key pair.
      */
-    private com.tananaev.adblib.AdbCrypto crypto;
+    private volatile com.tananaev.adblib.AdbCrypto crypto;
 
     /**
      * Specifies whether this connection has already sent a signed token.
@@ -74,13 +74,13 @@ public class AdbConnection implements Closeable {
     /**
      * A hash map of our open streams indexed by local ID.
      **/
-    private HashMap<Integer, AdbStream> openStreams;
+    private volatile ConcurrentHashMap<Integer, AdbStream> openStreams;
 
     /**
      * Internal constructor to initialize some internal state
      */
     private AdbConnection() {
-        openStreams = new HashMap<Integer, AdbStream>();
+        openStreams = new ConcurrentHashMap<Integer, AdbStream>();
         lastLocalId = 0;
         connectionThread = createConnectionThread();
     }
@@ -186,8 +186,10 @@ public class AdbConnection implements Closeable {
                                     }
 
                                     /* Write the AUTH reply */
-                                    conn.outputStream.write(packet);
-                                    conn.outputStream.flush();
+                                    synchronized (conn.outputStream) {
+                                        conn.outputStream.write(packet);
+                                        conn.outputStream.flush();
+                                    }
                                 }
                                 break;
 
@@ -261,8 +263,10 @@ public class AdbConnection implements Closeable {
             throw new IllegalStateException("Already connected");
 
         /* Write the CONNECT packet */
-        outputStream.write(AdbProtocol.generateConnect());
-        outputStream.flush();
+        synchronized (outputStream) {
+            outputStream.write(AdbProtocol.generateConnect());
+            outputStream.flush();
+        }
 
         /* Start the connection thread to respond to the peer */
         connectAttempted = true;
@@ -310,8 +314,10 @@ public class AdbConnection implements Closeable {
         openStreams.put(localId, stream);
 
         /* Send the open */
-        outputStream.write(AdbProtocol.generateOpen(localId, destination));
-        outputStream.flush();
+        synchronized (outputStream) {
+            outputStream.write(AdbProtocol.generateOpen(localId, destination));
+            outputStream.flush();
+        }
 
         /* Wait for the connection thread to receive the OKAY */
         synchronized (stream) {

--- a/src/main/java/com/tananaev/adblib/AdbStream.java
+++ b/src/main/java/com/tananaev/adblib/AdbStream.java
@@ -16,32 +16,32 @@ public class AdbStream implements Closeable {
     /**
      * The AdbConnection object that the stream communicates over
      */
-    private AdbConnection adbConn;
+    private final AdbConnection adbConn;
 
     /**
      * The local ID of the stream
      */
-    private int localId;
+    private final int localId;
 
     /**
      * The remote ID of the stream
      */
-    private int remoteId;
+    private volatile int remoteId;
 
     /**
      * Indicates whether a write is currently allowed
      */
-    private AtomicBoolean writeReady;
+    private final AtomicBoolean writeReady;
 
     /**
      * A queue of data from the target's write packets
      */
-    private Queue<byte[]> readQueue;
+    private final Queue<byte[]> readQueue;
 
     /**
      * Indicates whether the connection is closed already
      */
-    private boolean isClosed;
+    private volatile boolean isClosed;
 
     /**
      * Creates a new AdbStream object on the specified AdbConnection
@@ -79,8 +79,11 @@ public class AdbStream implements Closeable {
     void sendReady() throws IOException {
         /* Generate and send a READY packet */
         byte[] packet = AdbProtocol.generateReady(localId, remoteId);
-        adbConn.outputStream.write(packet);
-        adbConn.outputStream.flush();
+
+        synchronized (adbConn.outputStream) {
+            adbConn.outputStream.write(packet);
+            adbConn.outputStream.flush();
+        }
     }
 
     /**
@@ -184,10 +187,13 @@ public class AdbStream implements Closeable {
 
         /* Generate a WRITE packet and send it */
         byte[] packet = AdbProtocol.generateWrite(localId, remoteId, payload);
-        adbConn.outputStream.write(packet);
 
-        if (flush)
-            adbConn.outputStream.flush();
+        synchronized (adbConn.outputStream) {
+            adbConn.outputStream.write(packet);
+
+            if (flush)
+                adbConn.outputStream.flush();
+        }
     }
 
     /**
@@ -207,8 +213,11 @@ public class AdbStream implements Closeable {
         }
 
         byte[] packet = AdbProtocol.generateClose(localId, remoteId);
-        adbConn.outputStream.write(packet);
-        adbConn.outputStream.flush();
+
+        synchronized (adbConn.outputStream) {
+            adbConn.outputStream.write(packet);
+            adbConn.outputStream.flush();
+        }
     }
 
     /**


### PR DESCRIPTION
I noticed what appear to be a few different thread-safety issues, particularly around the `.open()` method when a pre-existing stream is already sending and receiving data.

Specifically, the stream map was being read and written by the connection and main threads simultaneously. The other main one was the output stream was being written to by multiple threads simultaneously. There are also a bunch of fields that are being accessed from multiple threads without the `volatile` keyword, so I've added it to most of them or made them `final` to make things easier to reason about.

When in doubt about whether something was thread-safe, I erred on the side of correctness and added `volatile` or `synchronized`, since I think correctness is more important than performance for most use cases.