### PR TITLE
Guarded against spurious wakeups during connection

### DIFF
--- a/src/main/java/com/tananaev/adblib/AdbConnection.java
+++ b/src/main/java/com/tananaev/adblib/AdbConnection.java
@@ -286,11 +286,8 @@ public class AdbConnection implements Closeable {
         /* Wait for the connection to go live */
         synchronized (this) {
             long timeoutEndMillis = System.currentTimeMillis() + unit.toMillis(timeout);
-            long remainingTimeoutMillis = unit.toMillis(timeout);
-
-            while (!connected && connectAttempted && remainingTimeoutMillis > 0) {
-                wait(remainingTimeoutMillis);
-                remainingTimeoutMillis = timeoutEndMillis - System.currentTimeMillis();
+            while (!connected && connectAttempted && timeoutEndMillis - System.currentTimeMillis() > 0) {
+                wait(timeoutEndMillis - System.currentTimeMillis());
             }
 
             if (!connected)

--- a/src/main/java/com/tananaev/adblib/AdbConnection.java
+++ b/src/main/java/com/tananaev/adblib/AdbConnection.java
@@ -258,14 +258,14 @@ public class AdbConnection implements Closeable {
      * @throws InterruptedException If we are unable to wait for the connection to finish
      */
     public void connect() throws IOException, InterruptedException {
-        connect(0, TimeUnit.MILLISECONDS);
+        connect(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
     }
 
     /**
      * Connects to the remote device. This routine will block until the connection
      * completes or the timeout elapses.
      *
-     * @param timeout the time to wait for the lock, or {@code 0} to wait indefinitely
+     * @param timeout the time to wait for the lock
      * @param unit the time unit of the timeout argument
      * @return {@code true} if the connection was established, or {@code false} if the connection timed out
      * @throws IOException          If the socket fails while connecting
@@ -286,17 +286,16 @@ public class AdbConnection implements Closeable {
         /* Wait for the connection to go live */
         synchronized (this) {
             long timeoutDurationMillis = unit.toMillis(timeout);
-            boolean hasTimeout = timeoutDurationMillis != 0;
             long timeoutEndMillis = System.currentTimeMillis() + timeoutDurationMillis;
             long remainingTimeoutMillis = timeoutDurationMillis;
 
-            while (!connected && connectAttempted && (!hasTimeout || remainingTimeoutMillis > 0)) {
+            while (!connected && connectAttempted && remainingTimeoutMillis > 0) {
                 wait(remainingTimeoutMillis);
                 remainingTimeoutMillis = timeoutEndMillis - System.currentTimeMillis();
             }
 
             if (!connected)
-                if (hasTimeout && connectAttempted)
+                if (connectAttempted)
                     return false;
                 else
                     throw new IOException("Connection failed");

--- a/src/main/java/com/tananaev/adblib/AdbConnection.java
+++ b/src/main/java/com/tananaev/adblib/AdbConnection.java
@@ -238,7 +238,7 @@ public class AdbConnection implements Closeable {
 
         synchronized (this) {
             /* Block if a connection is pending, but not yet complete */
-            if (!connected)
+            while (!connected && connectAttempted)
                 wait();
 
             if (!connected) {
@@ -270,7 +270,7 @@ public class AdbConnection implements Closeable {
 
         /* Wait for the connection to go live */
         synchronized (this) {
-            if (!connected)
+            while (!connected && connectAttempted)
                 wait();
 
             if (!connected) {
@@ -297,7 +297,7 @@ public class AdbConnection implements Closeable {
 
         /* Wait for the connect response */
         synchronized (this) {
-            if (!connected)
+            while (!connected && connectAttempted)
                 wait();
 
             if (!connected) {

--- a/src/main/java/com/tananaev/adblib/AdbConnection.java
+++ b/src/main/java/com/tananaev/adblib/AdbConnection.java
@@ -285,9 +285,8 @@ public class AdbConnection implements Closeable {
 
         /* Wait for the connection to go live */
         synchronized (this) {
-            long timeoutDurationMillis = unit.toMillis(timeout);
-            long timeoutEndMillis = System.currentTimeMillis() + timeoutDurationMillis;
-            long remainingTimeoutMillis = timeoutDurationMillis;
+            long timeoutEndMillis = System.currentTimeMillis() + unit.toMillis(timeout);
+            long remainingTimeoutMillis = unit.toMillis(timeout);
 
             while (!connected && connectAttempted && remainingTimeoutMillis > 0) {
                 wait(remainingTimeoutMillis);


### PR DESCRIPTION
Looks like a spurious wake-up during the connection would cause the library to `throw new IOException("Connection failed")` even if the connection was progressing normally